### PR TITLE
Get Started Command List added to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # ICP-Developer
+
+## Instructions
+
+To get started, run the following commands
+
+    > npm install
+    > dfx start --background --clean
+    > dfx deploy
+    > dfx generate # Run this if dfx deploy fails, and then run dfx deploy again
+    > npm run serve


### PR DESCRIPTION
Agrega instrucciones para correr el código, se coloca el comando de dfx generate como opcional (con sus correspondientes notas) ya que a veces cuando intentaba replicar no era necesario o generaba error si se corría antes de deploy.